### PR TITLE
Allows for cached external projects

### DIFF
--- a/scripts/PackageLookup.cmake
+++ b/scripts/PackageLookup.cmake
@@ -80,7 +80,7 @@ macro(_find_package_for_lookup package REQUIRED QUIET DOWNLOAD CHECK)
     # First try and find package (unless downloading by default)
     set(dolook TRUE)
     if(${DOWNLOAD} AND NOT ${recursive})
-        if(CHECK)
+        if(${CHECK})
             set(do_rootchange TRUE)
         endif()
         set(dolook FALSE)
@@ -237,7 +237,7 @@ macro(lookup_package package)
     # First try and locate package
     _find_package_for_lookup(${package}
         "${${package}_REQUIRED}" "${${package}_QUIET}"
-        "${${package}_DOWNLOAD_BY_DEFAULT}" "${${package}_CHECK_EXACT}"
+        "${${package}_DOWNLOAD_BY_DEFAULT}" "${${package}_CHECK_EXTERNAL}"
         ${${package}_UNPARSED_ARGUMENTS}
     )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,11 +10,18 @@ cmake_test(add_to_path)
 
 find_program(Hg_EXECUTABLE hg)
 if("${CMAKE_VERSION}" VERSION_GREATER 2.8.9 AND Hg_EXECUTABLE)
-   cmake_test(lookup_eigen SOURCE)
+    cmake_test(lookup_eigen SOURCE -DLOOKUP_EIGEN=TRUE)
+    cmake_test(use_external)
+    cmake_test(use_external_download_by_default)
+    set_tests_properties(
+        cmake_test_use_external cmake_test_use_external_download_by_default
+        PROPERTIES DEPENDS cmake_test_lookup_eigen
+    )
 endif()
 find_program(svn_EXECUTABLE svn)
 if(svn_EXECUTABLE)
-    cmake_test(addgtest NOEXEC SOURCE --test-command ${CMAKE_MAKE_PROGRAM} test)
+    cmake_test(addgtest NOEXEC SOURCE
+        --test-command ${CMAKE_MAKE_PROGRAM} test)
 endif()
 
 add_subdirectory(cpp11)

--- a/tests/use_external.cmake
+++ b/tests/use_external.cmake
@@ -1,0 +1,13 @@
+find_package(GreatCMakeCookOff NO_MODULE PATHS ${cookoff_path} REQUIRED)
+initialize_cookoff()
+
+set(EXTERNAL_ROOT "${PROJECT_BINARY_DIR}/../lookup_eigen/external")
+include(PackageLookup)
+lookup_package(Eigen3)
+
+if(TARGET Eigen3)
+    message(FATAL_ERROR "Did not expect eigen3 target")
+endif()
+if(NOT Eigen3_FOUND)
+    message(FATAL_ERROR "Expected eigen to be in external area ${EXTERNAL_ROOT}")
+endif()

--- a/tests/use_external_download_by_default.cmake
+++ b/tests/use_external_download_by_default.cmake
@@ -1,0 +1,13 @@
+find_package(GreatCMakeCookOff NO_MODULE PATHS ${cookoff_path} REQUIRED)
+initialize_cookoff()
+
+set(EXTERNAL_ROOT "${PROJECT_BINARY_DIR}/../lookup_eigen/external")
+include(PackageLookup)
+lookup_package(Eigen3 DOWNLOAD_BY_DEFAULT CHECK_EXTERNAL)
+
+if(TARGET Eigen3)
+    message(FATAL_ERROR "Did not expect eigen3 target")
+endif()
+if(NOT Eigen3_FOUND)
+    message(FATAL_ERROR "Expected eigen to be in external area ${EXTERNAL_ROOT}")
+endif()


### PR DESCRIPTION
Adds more tests for package lookup.
Closes #7
