### PR TITLE
Fixed Numpy MKL Lookup for Anaconda Python 3.4

### DIFF
--- a/modules/numpy_mkl.py
+++ b/modules/numpy_mkl.py
@@ -129,12 +129,14 @@ def get_mkl_dirs_and_libs_like_numpy():
     from sys import platform
     from os import environ
     from subprocess import check_output
+    from glob import glob
     try:
         import numpy
     except ImportError:
         raise Exception("MKL autodetection failed: NumPy could not "
                         "be imported. Specify MKL location manually")
-    lapack_lite_path = join(dirname(numpy.__file__), 'linalg', 'lapack_lite.so')
+
+    lapack_lite_path = glob(join(dirname(numpy.__file__), 'linalg', 'lapack_lite*.so'))[0]
     if not isfile(lapack_lite_path):
         raise Exception("MKL autodetection failed: '"+lapack_lite_path+
                         "' is not a file. Specify MKL location manually")


### PR DESCRIPTION
Fix the Numpy MKL Look Up in Anaconda Python on Linux. The correct name of the shared object there is 'lapack_lite.cpython-34m.so'. Python now uses a glob to look for any file starting with lapack_lite and ending with .so, and picks the first found file.
