### PR TITLE
Update the link from catch2

### DIFF
--- a/scripts/AddCatchTest.cmake
+++ b/scripts/AddCatchTest.cmake
@@ -5,7 +5,7 @@ if(NOT CATCH_FOUND)
   # setups things so include can be found
   include(PackageLookup)
   set(catch_url
-      https://raw.githubusercontent.com/philsquared/Catch/master/single_include/catch.hpp)
+      https://raw.githubusercontent.com/catchorg/Catch2/master/single_include/catch2/catch.hpp)
   set(catch_file "${EXTERNAL_ROOT}/include/catch.hpp")
   file(MAKE_DIRECTORY "${EXTERNAL_ROOT}/include")
   file(DOWNLOAD ${catch_url} "${catch_file}")


### PR DESCRIPTION
As shown in [catch2](https://github.com/catchorg/Catch2/commit/44722f9ed3d019bdff92d003f9e73333e68c503a#diff-517f9182596f90e5f6dcf26ec964e99c) they've recently changed their path.